### PR TITLE
Try and fix `stat` semihosting service wrt. QEMU

### DIFF
--- a/em/em_sys.c
+++ b/em/em_sys.c
@@ -70,6 +70,7 @@ int em_ecall(rv_ctx *ctx) {
     } rv_stat_t;
     rv_stat_t st;
     memset(&st, 0, sizeof(st));
+    int ret = 0;
 #if 0
     st.st_dev = 0x18;
     st.st_ino = 0x4;
@@ -81,9 +82,9 @@ int em_ecall(rv_ctx *ctx) {
     st.st_size = 0x0;
     st.st_blksize = 0x400;
     st.st_blocks = 0x0;
-#elif 1
+#elif 0
     struct stat hst;
-    fstat(ctx->a0, &hst);
+    ret = fstat(ctx->a0, &hst);
     st.st_dev = hst.st_dev;
     st.st_ino = hst.st_ino;
     st.st_mode = hst.st_mode;
@@ -96,6 +97,7 @@ int em_ecall(rv_ctx *ctx) {
     st.st_blocks = hst.st_blocks;
 #endif
     ctx->write(&st, ctx->a1, sizeof(st));
+    ctx->a0 = ret;
     // return 1;
     break;
   }
@@ -104,7 +106,13 @@ int em_ecall(rv_ctx *ctx) {
     return 1;
     break;
   }
+  case 214: {
+    log_printf(1, "FIXME sbrk a0=%" PRIx32 " a1=%" PRIx32 "\n", ctx->a0,
+               ctx->a1);
+    break;
+  }
   default:
+    log_printf(1, "unimplemented a7=%" PRIu32 "\n", ctx->a7);
     die();
     return 1;
   }

--- a/em/em_sys.c
+++ b/em/em_sys.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "em_sys.h"
 
@@ -11,7 +12,7 @@
     exit(1);                                                                   \
   } while (0)
 
-static int g_log = 0;
+static int g_log = 1;
 #define log_printf(l, ...)                                                     \
   do {                                                                         \
     if (l <= g_log) {                                                          \
@@ -35,6 +36,8 @@ int em_ecall(rv_ctx *ctx) {
     break;
   }
   case 80: {
+    log_printf(1, "FIXME fstat a0=%" PRIx32 " a1=%" PRIx32 "\n", ctx->a0,
+               ctx->a1);
     typedef uint16_t rv_dev_t;
     typedef uint16_t rv_ino_t;
     typedef uint32_t rv_mode_t;
@@ -67,6 +70,7 @@ int em_ecall(rv_ctx *ctx) {
     } rv_stat_t;
     rv_stat_t st;
     memset(&st, 0, sizeof(st));
+#if 0
     st.st_dev = 0x18;
     st.st_ino = 0x4;
     st.st_mode = 0x2190;
@@ -77,9 +81,21 @@ int em_ecall(rv_ctx *ctx) {
     st.st_size = 0x0;
     st.st_blksize = 0x400;
     st.st_blocks = 0x0;
+#elif 1
+    struct stat hst;
+    fstat(ctx->a0, &hst);
+    st.st_dev = hst.st_dev;
+    st.st_ino = hst.st_ino;
+    st.st_mode = hst.st_mode;
+    st.st_nlink = hst.st_nlink;
+    st.st_uid = hst.st_uid;
+    st.st_gid = hst.st_gid;
+    st.st_rdev = hst.st_rdev;
+    st.st_size = hst.st_size;
+    st.st_blksize = hst.st_blksize;
+    st.st_blocks = hst.st_blocks;
+#endif
     ctx->write(&st, ctx->a1, sizeof(st));
-    log_printf(1, "FIXME fstat a0=%" PRIx32 " a1=%" PRIx32 "\n", ctx->a0,
-               ctx->a1);
     // return 1;
     break;
   }

--- a/em/esw.c
+++ b/em/esw.c
@@ -34,6 +34,7 @@ int foo(int a, int b) {
 #endif
   write(1, GREETING, 12);
   struct stat st;
+  memset(&st, 0, sizeof(st));
 #ifdef __riscv
   // return sizeof(st.st_dev); // 2
   // return sizeof(st.st_ino);//2
@@ -49,8 +50,23 @@ int foo(int a, int b) {
   // return sizeof(st.st_mtim); // 16
   // return sizeof(st.st_ctim); // 16
   // return sizeof(st.st_atim.tv_sec); // 8
-  fstat(0, &st);
-  // return st.st_dev;
+  // fstat(0, &st);
+  // return st.st_dev; // 24
+  // return st.st_ino; // 6
+  // return st.st_mode; // 144
+  // return st.st_nlink; // 1
+  // return st.st_uid; // 232
+  // return st.st_gid; // 5
+  // return st.st_rdev; // 3
+  // return st.st_size; // 0
+  // return st.st_blksize; // 0
+  // return st.st_blocks; // 0
+  // return st.st_atim.tv_sec; // 106
+  // return st.st_atim.tv_nsec; // 0
+  // return st.st_mtim.tv_sec; // 227
+  // return st.st_mtim.tv_nsec; // 0
+  // return st.st_ctim.tv_sec; // 0
+  // return st.st_ctim.tv_nsec; // 0
 #else
   // return sizeof(st.st_dev); // 8
   // return sizeof(st.st_ino);//8
@@ -77,7 +93,7 @@ int foo(int a, int b) {
   printf("atim.sec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_sec);
   printf("atim.nsec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_nsec);
 #endif
-  // puts("hello puts\n");
+  puts("hello puts\n");
   // printf("hello %s\n", "printf");
   return a + b;
   // return -5;

--- a/em/esw.c
+++ b/em/esw.c
@@ -1,6 +1,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -79,7 +80,22 @@ int foo(int a, int b) {
 
   // return sizeof(st.st_atim);//16
   // return sizeof(st);//144
-#ifndef __riscv
+#ifdef __riscv
+#if 0
+  printf("dev=%" PRIx32 "\n", (uint32_t)st.st_dev);
+  printf("ino=%" PRIx32 "\n", (uint32_t)st.st_ino);
+  printf("mode=%" PRIx32 "\n", (uint32_t)st.st_mode);
+  printf("nlink=%" PRIx32 "\n", (uint32_t)st.st_nlink);
+  printf("uid=%" PRIx32 "\n", (uint32_t)st.st_uid);
+  printf("gid=%" PRIx32 "\n", (uint32_t)st.st_gid);
+  printf("rdev=%" PRIx32 "\n", (uint32_t)st.st_rdev);
+  printf("size=%" PRIx32 "\n", (uint32_t)st.st_size);
+  printf("blksize=%" PRIx32 "\n", (uint32_t)st.st_blksize);
+  printf("blocks=%" PRIx32 "\n", (uint32_t)st.st_blocks);
+  printf("atim.sec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_sec);
+  printf("atim.nsec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_nsec);
+#endif
+#else
   printf("dev=%" PRIx32 "\n", (uint32_t)st.st_dev);
   printf("ino=%" PRIx32 "\n", (uint32_t)st.st_ino);
   printf("mode=%" PRIx32 "\n", (uint32_t)st.st_mode);

--- a/em/esw.c
+++ b/em/esw.c
@@ -109,7 +109,7 @@ int foo(int a, int b) {
   printf("atim.sec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_sec);
   printf("atim.nsec=%" PRIx32 "\n", (uint32_t)st.st_atim.tv_nsec);
 #endif
-  puts("hello puts\n");
+//  puts("hello puts\n");
   // printf("hello %s\n", "printf");
   return a + b;
   // return -5;

--- a/em/rv.c
+++ b/em/rv.c
@@ -286,13 +286,8 @@ int rv_execute(rv_ctx *ctx) {
         log_printf(1, "SLTU rd=%s funct3=%" PRIx8 " rs1=%s rs2=%s",
                    rv_rname(i.r.rd), i.r.funct3, rv_rname(i.r.rs1),
                    rv_rname(i.r.rs2));
-        if (i.r.rs1) {
-          printf("rs1 should be zero!\n");
-          die();
-          return 1;
-        }
         if (i.r.rd)
-          ctx->x[i.r.rd] = ctx->x[i.r.rs2] != 0 ? 1 : 0;
+          ctx->x[i.r.rd] = ctx->x[i.r.rs1] < ctx->x[i.r.rs2] ? 1 : 0;
         break;
       default:
         die();
@@ -428,7 +423,7 @@ int rv_execute(rv_ctx *ctx) {
       log_printf(1, "BLT rs1=%s rs2=%s imm=%" PRIx32 "\n", rv_rname(i.b.rs1),
                  rv_rname(i.b.rs2), imm);
       if ((int32_t)(ctx->x[i.b.rs1]) < (int32_t)(ctx->x[i.b.rs2])) {
-        ctx->pc = ctx->pc - 4 + imm;
+        ctx->pc = ctx->pc - 4 + rv_signext(imm, 12);
       }
       break;
     }

--- a/em/rv.c
+++ b/em/rv.c
@@ -118,6 +118,15 @@ void rv_print_regs(rv_ctx *ctx) {
   }
 }
 
+int64_t rv_signext64(int64_t val, int sbit) {
+  int64_t sign = 0;
+  int64_t mask = 1 << sbit;
+  if (val & mask) {
+    sign = -1 & ~(mask - 1);
+  }
+  return val | sign;
+}
+
 int32_t rv_signext(int32_t val, int sbit) {
   int32_t sign = 0;
   int32_t mask = 1 << sbit;
@@ -277,6 +286,21 @@ int rv_execute(rv_ctx *ctx) {
         if (i.r.rd)
           ctx->x[i.r.rd] = ctx->x[i.r.rs1] << (ctx->x[i.r.rs2] & 0x1f);
         break;
+#ifdef RV32M
+      case RV_MULH:
+        log_printf(1, "MULH rd=%s funct3=%" PRIx8 " rs1=%s rs2=%s",
+                   rv_rname(i.r.rd), i.r.funct3, rv_rname(i.r.rs1),
+                   rv_rname(i.r.rs2));
+        if (i.r.rd) {
+//          int64_t rs1 = rv_signext64(ctx->x[i.r.rs1], 32);
+          int64_t rs2 = rv_signext64(ctx->x[i.r.rs2], 32);
+          int64_t rs1 = ctx->x[i.r.rs1];
+//          int64_t rs2 = ctx->x[i.r.rs2];
+          log_printf(1, "RS1=%" PRIx64 " RS2=%" PRIx64 "\n", rs1, rs2);
+          ctx->x[i.r.rd] = (rs1 * rs2) >> 32;
+        }
+        break;
+#endif
       default:
         die();
         return 1;

--- a/em/rv.c
+++ b/em/rv.c
@@ -203,6 +203,12 @@ int rv_execute(rv_ctx *ctx) {
         ctx->x[i.i.rd] =
             ctx->x[i.i.rs1] < (uint32_t)rv_signext(i.i.imm_11_0, 11) ? 1 : 0;
       break;
+    case RV_XORI:
+      log_printf(1, "XORI rd=%s funct3=%" PRIx8 " rs1=%s imm11_0=%" PRIx32,
+                 rv_rname(i.i.rd), i.i.funct3, rv_rname(i.i.rs1), i.i.imm_11_0);
+      if (i.i.rd)
+        ctx->x[i.i.rd] = ctx->x[i.i.rs1] ^ rv_signext(i.i.imm_11_0, 11);
+      break;
     case RV_ORI:
       log_printf(1, "ORI rd=%s funct3=%" PRIx8 " rs1=%s imm11_0=%" PRIx32,
                  rv_rname(i.i.rd), i.i.funct3, rv_rname(i.i.rs1), i.i.imm_11_0);

--- a/em/rv.c
+++ b/em/rv.c
@@ -31,7 +31,7 @@ int rv_set_log(rv_ctx *ctx, int log) {
 }
 
 void rv_print_insn(rv_ctx *ctx) {
-  printf("PC=%08" PRIx32 ": a4=%08" PRIx32 " ", ctx->pc, ctx->a4);
+  printf("PC 0x%08" PRIx32 " a4=%08" PRIx32 " ", ctx->pc, ctx->a4);
   rv_insn i;
   i.insn = ctx->last_insn;
   printf("0x%08" PRIx32 " ", i.insn);
@@ -147,7 +147,7 @@ int rv_execute(rv_ctx *ctx) {
     if (g_log >= 1) {
       rv_print_regs(ctx);
     }
-    log_printf(1, "PC=%08" PRIx32 ": a4=%08" PRIx32 " ", ctx->pc - 4, ctx->a4);
+    log_printf(1, "PC 0x%08" PRIx32 " a4=%08" PRIx32 " ", ctx->pc - 4, ctx->a4);
   }
 
   switch (i.opc) {
@@ -528,6 +528,7 @@ int rv_execute(rv_ctx *ctx) {
     if (i.j.rd)
       ctx->x[i.j.rd] = ctx->pc;
     ctx->pc = ctx->pc - 4 + rv_signext(imm, 20);
+    log_printf(1, "JAL PC=%" PRIx32 "\n", ctx->pc);
     break;
   }
 
@@ -569,6 +570,7 @@ int rv_execute(rv_ctx *ctx) {
     }
     break;
   default:
+    printf("Unknown opc=%d\n", i.opc);
     die();
     return 1;
   }

--- a/em/rv.h
+++ b/em/rv.h
@@ -35,6 +35,7 @@ typedef enum {
   // OP-IMM
   RV_ADDI = 0x0,
   RV_SLTIU = 0x3,
+  RV_XORI = 0x4,
   RV_ORI = 0x6,
   RV_ANDI = 0x7,
   // SHIFT

--- a/em/rv.h
+++ b/em/rv.h
@@ -74,6 +74,7 @@ typedef enum {
   RV_SUB = 0x20,
 #ifdef RV32M
   RV_MUL = 0x01,
+  RV_MULH = 0x01,
   RV_MULHU = 0x01,
   RV_DIV = 0x01,
   RV_REM = 0x01,


### PR DESCRIPTION
Currently our `stat` semihosting service is hardcoded/broken,
and doesn't match with QEMU's one.

investigate a clever way to allow for QEMU check to succeed

`stat` is one of the required services for high-level APIs eg: `printf`, to work
Fixing `stat` might give clue how to fix other similar dependencies, eg: `sbrk`